### PR TITLE
feat: 채팅 목록 조회 정렬기준 변경

### DIFF
--- a/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
@@ -15,6 +15,7 @@ import com.hyunsolution.dangu.user.domain.UserRepository;
 import com.hyunsolution.dangu.user.exception.UserNotFoundException;
 import com.hyunsolution.dangu.workspace.domain.Workspace;
 import com.hyunsolution.dangu.workspace.domain.WorkspaceRepository;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -46,7 +47,7 @@ public class ChattingService {
     public List<GetChatRoomsResponse> getChatRooms(Long userId) {
         List<Workspace> chatRooms = workspaceRepository.findByParticipantUserId(userId);
         return chatRooms.stream()
-                .filter(chatRoom -> chatRoom.getParticipants().size() > 1)
+                .sorted(Comparator.comparing(Workspace::getChatUpdateAt).reversed())
                 .map(
                         chatRoom ->
                                 GetChatRoomsResponse.of(

--- a/src/main/java/com/hyunsolution/dangu/participant/controller/ParticipantController.java
+++ b/src/main/java/com/hyunsolution/dangu/participant/controller/ParticipantController.java
@@ -22,7 +22,7 @@ public class ParticipantController {
     private final WorkspaceRepository workspaceRepository;
     private final ParticipantService participantService;
 
-    //사용자 매칭 버튼 클릭
+    // 사용자 매칭 버튼 클릭
     @PostMapping("/participant/matching/{roomNumber}")
     public ApiResponse<?> matching(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long id,

--- a/src/main/java/com/hyunsolution/dangu/participant/service/ParticipantService.java
+++ b/src/main/java/com/hyunsolution/dangu/participant/service/ParticipantService.java
@@ -44,7 +44,10 @@ public class ParticipantService {
             }
         }
         // 게임방 테이블 속 매칭 결과를 true로 바꿈
-        Workspace workspace1 = workspaceRepository.findById(workspaceId).orElseThrow(()-> WorkspaceNotFoundException.EXCEPTION);
+        Workspace workspace1 =
+                workspaceRepository
+                        .findById(workspaceId)
+                        .orElseThrow(() -> WorkspaceNotFoundException.EXCEPTION);
         workspace1.acceptFinal();
     }
 

--- a/src/main/java/com/hyunsolution/dangu/user/domain/UserRepository.java
+++ b/src/main/java/com/hyunsolution/dangu/user/domain/UserRepository.java
@@ -1,8 +1,7 @@
 package com.hyunsolution.dangu.user.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUid(String uid);

--- a/src/main/java/com/hyunsolution/dangu/workspace/domain/Workspace.java
+++ b/src/main/java/com/hyunsolution/dangu/workspace/domain/Workspace.java
@@ -2,6 +2,7 @@ package com.hyunsolution.dangu.workspace.domain;
 
 import com.hyunsolution.dangu.participant.domain.Participant;
 import com.hyunsolution.dangu.user.domain.User;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
@@ -12,8 +13,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -39,6 +38,9 @@ public class Workspace {
     @Column(name = "created_at", nullable = false)
     @CreatedDate
     private LocalDateTime createdAt;
+
+    @Column(name = "ch_update_at")
+    private LocalDateTime chatUpdateAt;
 
     @OneToMany(mappedBy = "workspace", fetch = FetchType.LAZY)
     private List<Participant> participants = new ArrayList<>();

--- a/src/main/java/com/hyunsolution/dangu/workspace/domain/WorkspaceRepository.java
+++ b/src/main/java/com/hyunsolution/dangu/workspace/domain/WorkspaceRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
     @EntityGraph(attributePaths = {"participants"})
     @Query(
-            "select w from Workspace w where exists (select 1 from Participant p where p.workspace = w and p.user.id = :userId)")
+            "select w from Workspace w where exists (select 1 from Participant p where p.workspace = w and p.user.id = :userId) and w.chatUpdateAt is not null")
     List<Workspace> findByParticipantUserId(Long userId);
 }

--- a/src/main/java/com/hyunsolution/dangu/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/hyunsolution/dangu/workspace/service/WorkspaceService.java
@@ -9,11 +9,8 @@ import com.hyunsolution.dangu.user.exception.UserNotFoundException;
 import com.hyunsolution.dangu.workspace.domain.Workspace;
 import com.hyunsolution.dangu.workspace.domain.WorkspaceRepository;
 import com.hyunsolution.dangu.workspace.dto.response.GetWorkspacesResponse;
-
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,8 +34,13 @@ public class WorkspaceService {
         LocalDateTime dateFilter = LocalDateTime.now().minusDays(1);
         return workSpaceRepository.findAll().stream()
                 .filter(workspace -> !workspace.isMatched())
-                .filter(workspace -> workspace.getCreatedAt().isAfter(dateFilter)) //게임방 조회: 유지 시간은 24h
-                .map(workspace ->GetWorkspacesResponse.of(workspace.getId(), workspace.getCreator().getUid()))
+                .filter(
+                        workspace ->
+                                workspace.getCreatedAt().isAfter(dateFilter)) // 게임방 조회: 유지 시간은 24h
+                .map(
+                        workspace ->
+                                GetWorkspacesResponse.of(
+                                        workspace.getId(), workspace.getCreator().getUid()))
                 .toList();
     }
 }


### PR DESCRIPTION
## ⚠️ 연관된 이슈 번호 <!--이슈번호를 작성해주세요 e.g. #11 -->
- close #53
## 📋 작업 내용
1. Workspace Entity에 chatUdpateAt 컬럼 추가
2. filter(chatRoom -> chatRoom.getParticipants().size() > 1) 대신 chatUpdateAt이 null이 아닌 것 조회하는 것으로 수정
  - 단순 참가자 2명 이상이 아닌 입력된 채팅이 있는 것을 조회하도록 수정하였습니다.
3. 채팅 목록 조회 할 때 chatUpdateAt 내리차순 정렬
  - 채팅 목록을 조회 할 때 최근에 입력된 채팅이 가장 상단에 있어야 함으로 chatUpdateAt 내림차순으로 정렬하였습니다.
## 📷 스크린샷(선택) 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> @Lee-Dahyeon 채팅 입력 할 때 Workspace의 chatUpdateAt을 현재 시간으로 갱신해주세요
