### PR TITLE
feature: 채팅방목록 조회 에러 해결(#68)

### DIFF
--- a/src/main/java/com/hyunsolution/dangu/chatting/domain/Chatting.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/domain/Chatting.java
@@ -27,7 +27,7 @@ public class Chatting extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
-            name = "chatRoom_id",
+            name = "chat_room_id",
             nullable = false,
             foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private ChatRoom chatRoom;

--- a/src/main/java/com/hyunsolution/dangu/chatting/domain/Chatting.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/domain/Chatting.java
@@ -18,7 +18,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@Table(indexes = {@Index(name = "idx_chatRoom_id_id", columnList = "chatRoom_id, id DESC")})
+@Table(indexes = {@Index(name = "idx_chat_room_id_id", columnList = "chat_room_id, id DESC")})
 @DynamicInsert
 public class Chatting extends BaseEntity {
     @Id

--- a/src/main/java/com/hyunsolution/dangu/chatting/domain/ChattingRepository.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/domain/ChattingRepository.java
@@ -12,7 +12,7 @@ public interface ChattingRepository extends JpaRepository<Chatting, Long> {
     @Query(
             value =
                     "select c.content from chatting c where c.id = ("
-                            + "select MAX(id) from chatting where chatRoom_Id = :chatRoomId)",
+                            + "select MAX(id) from chatting where chat_room_Id = :chatRoomId)",
             nativeQuery = true)
     String findLastChattingContentByChatRoomId(Long chatRoomId);
 


### PR DESCRIPTION
## ⚠️ 연관된 이슈 번호 #68 
- close #68 
## 📋 작업 내용
- chat_room_Id 칼럼명 수정 
- chat_room_Id 칼럼명 수정 사항 index에 적용
- chat_room_Id 칼럼명 수정사항 findLastChattingContentByChatRoomId에 반영

## 📷 스크린샷(선택) 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> e.g. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
