### PR TITLE
fix: 웹소켓 연결 주소 변경

### DIFF
--- a/src/main/java/com/hyunsolution/dangu/common/config/webSocket/WebSocketSwaggerDocsController.java
+++ b/src/main/java/com/hyunsolution/dangu/common/config/webSocket/WebSocketSwaggerDocsController.java
@@ -11,7 +11,7 @@ public class WebSocketSwaggerDocsController {
             description =
                     """
             WebSocket URL, 구독 경로 및 발행 경로 안내
-            - WebSocket 접속 URL: wss://54.221.244.36:8080/chat
+            - WebSocket 접속 URL: wss://hyunsolution.duckdns.org/chat
             - STOMP 구독 주소: /topic/chat/{chatRoomId}
             - 메시지 전송 주소: /app/chat/{chatRoomId}
             """)

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -16,7 +16,7 @@
 
 <script>
     let client;
-    const socket = new WebSocket('wss://hyunsolution.duckdns.org/chat/');
+    const socket = new WebSocket('wss://hyunsolution.duckdns.org/chat');
     client = Stomp.over(socket);
 
     // WebSocket 연결 및 STOMP 클라이언트 초기화


### PR DESCRIPTION
## ⚠️ 연관된 이슈 번호 #80
- close #80 
## 📋 작업 내용
- 웹소켓 연결 주소 : wss://hyunsolution.duckdns.org/chat 으로 변경

## 📷 스크린샷(선택) 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> e.g. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
