### PR TITLE
feature: 채팅 조회시 상대방 이름 값 응답으로 보내기

### DIFF
--- a/src/main/java/com/hyunsolution/dangu/chatRoom/domain/ChatRoomRepository.java
+++ b/src/main/java/com/hyunsolution/dangu/chatRoom/domain/ChatRoomRepository.java
@@ -1,13 +1,18 @@
 package com.hyunsolution.dangu.chatRoom.domain;
 
 import java.util.List;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    @EntityGraph(attributePaths = {"participants"})
     @Query(
-            "select c from ChatRoom c where exists (select 1 from Participant p where p.chatRoom = c and p.user.id = :userId)")
-    List<ChatRoom> findByParticipantUserId(Long userId);
+            "select c from ChatRoom c join fetch c.participants p join fetch p.user u where u.id = :userId")
+    List<ChatRoom> findByParticipantUserIdWithEntityGraph(Long userId);
+
+    @Query(
+            "select distinct c from ChatRoom c "
+                    + "join fetch c.participants p "
+                    + "join fetch p.user "
+                    + "where c.id = :chatRoomId")
+    ChatRoom findByChatRoomIdWithFetchJoin(Long chatRoomId);
 }

--- a/src/main/java/com/hyunsolution/dangu/chatting/controller/ChattingController.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/controller/ChattingController.java
@@ -1,10 +1,7 @@
 package com.hyunsolution.dangu.chatting.controller;
 
 import com.hyunsolution.dangu.chatting.dto.request.ChatMessageRequest;
-import com.hyunsolution.dangu.chatting.dto.response.ChatMessageDetailResponse;
-import com.hyunsolution.dangu.chatting.dto.response.ChatMessageResponse;
-import com.hyunsolution.dangu.chatting.dto.response.GetChatRoomsResponse;
-import com.hyunsolution.dangu.chatting.dto.response.GetChattingsResponse;
+import com.hyunsolution.dangu.chatting.dto.response.*;
 import com.hyunsolution.dangu.chatting.service.ChattingService;
 import com.hyunsolution.dangu.common.apiResponse.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,10 +24,10 @@ public class ChattingController {
     @Operation(
             summary = "채팅방에 대한 채팅을 조회한다.",
             description = "워크스페이스(채팅방)에 대한 채팅을 조회한다. 워크스페이스 당 채팅방 하나 이기 때문에 워크스페이스를 채팅방이랑 같다고 생각")
-    public ApiResponse<List<GetChattingsResponse>> getChattings(
+    public ApiResponse<GetChattingsResponse> getChattings(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId,
             @PathVariable Long chatRoomId) {
-        List<GetChattingsResponse> responses = chattingService.getChattings(userId, chatRoomId);
+        GetChattingsResponse responses = chattingService.getChattings(userId, chatRoomId);
         return ApiResponse.success(responses);
     }
 

--- a/src/main/java/com/hyunsolution/dangu/chatting/dto/response/ChattingsDto.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/dto/response/ChattingsDto.java
@@ -1,7 +1,9 @@
 package com.hyunsolution.dangu.chatting.dto.response;
 
-public record ChattingsDto(String content, Long chattingId, boolean isOwn) {
-    public static ChattingsDto of(String content, Long chattingId, boolean isOwn) {
-        return new ChattingsDto(content, chattingId, isOwn);
+import com.hyunsolution.dangu.chatting.domain.MessageType;
+
+public record ChattingsDto(String content, Long chattingId, boolean isOwn, MessageType messageType) {
+    public static ChattingsDto of(String content, Long chattingId, boolean isOwn, MessageType messageType) {
+        return new ChattingsDto(content, chattingId, isOwn, messageType);
     }
 }

--- a/src/main/java/com/hyunsolution/dangu/chatting/dto/response/ChattingsDto.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/dto/response/ChattingsDto.java
@@ -1,0 +1,7 @@
+package com.hyunsolution.dangu.chatting.dto.response;
+
+public record ChattingsDto(String content, Long chattingId, boolean isOwn) {
+    public static ChattingsDto of(String content, Long chattingId, boolean isOwn) {
+        return new ChattingsDto(content, chattingId, isOwn);
+    }
+}

--- a/src/main/java/com/hyunsolution/dangu/chatting/dto/response/ChattingsDto.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/dto/response/ChattingsDto.java
@@ -2,8 +2,10 @@ package com.hyunsolution.dangu.chatting.dto.response;
 
 import com.hyunsolution.dangu.chatting.domain.MessageType;
 
-public record ChattingsDto(String content, Long chattingId, boolean isOwn, MessageType messageType) {
-    public static ChattingsDto of(String content, Long chattingId, boolean isOwn, MessageType messageType) {
+public record ChattingsDto(
+        String content, Long chattingId, boolean isOwn, MessageType messageType) {
+    public static ChattingsDto of(
+            String content, Long chattingId, boolean isOwn, MessageType messageType) {
         return new ChattingsDto(content, chattingId, isOwn, messageType);
     }
 }

--- a/src/main/java/com/hyunsolution/dangu/chatting/dto/response/GetChatRoomsResponse.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/dto/response/GetChatRoomsResponse.java
@@ -3,7 +3,7 @@ package com.hyunsolution.dangu.chatting.dto.response;
 import java.util.List;
 
 public record GetChatRoomsResponse(
-        Long chatRoomId, String lastMessage, List<String> otherPerson, int unReadCount) {
+        Long chatRoomId, String lastMessage, List<String> otherPeople, int unReadCount) {
     public static GetChatRoomsResponse of(
             Long chatRoomId, String lastMessage, List<String> otherPerson, int unReadCount) {
         return new GetChatRoomsResponse(chatRoomId, lastMessage, otherPerson, unReadCount);

--- a/src/main/java/com/hyunsolution/dangu/chatting/dto/response/GetChattingsResponse.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/dto/response/GetChattingsResponse.java
@@ -2,7 +2,7 @@ package com.hyunsolution.dangu.chatting.dto.response;
 
 import java.util.List;
 
-public record GetChattingsResponse(List<String> otherName, List<ChattingsDto> chattings) {
+public record GetChattingsResponse(List<String> otherPeople, List<ChattingsDto> chattings) {
     public static GetChattingsResponse of(List<String> otherName, List<ChattingsDto> chattings) {
         return new GetChattingsResponse(otherName, chattings);
     }

--- a/src/main/java/com/hyunsolution/dangu/chatting/dto/response/GetChattingsResponse.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/dto/response/GetChattingsResponse.java
@@ -1,7 +1,9 @@
 package com.hyunsolution.dangu.chatting.dto.response;
 
-public record GetChattingsResponse(String content, Long chattingId, boolean isOwn) {
-    public static GetChattingsResponse of(String content, Long chattingId, boolean isOwn) {
-        return new GetChattingsResponse(content, chattingId, isOwn);
+import java.util.List;
+
+public record GetChattingsResponse(List<String> otherName, List<ChattingsDto> chattings) {
+    public static GetChattingsResponse of(List<String> otherName, List<ChattingsDto> chattings) {
+        return new GetChattingsResponse(otherName, chattings);
     }
 }

--- a/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
@@ -11,8 +11,11 @@ import com.hyunsolution.dangu.chatting.domain.ChattingRepository;
 import com.hyunsolution.dangu.chatting.domain.MessageType;
 import com.hyunsolution.dangu.chatting.dto.response.ChatMessageDetailResponse;
 import com.hyunsolution.dangu.chatting.dto.response.GetChatRoomsResponse;
+import com.hyunsolution.dangu.chatting.dto.response.ChattingsDto;
 import com.hyunsolution.dangu.chatting.dto.response.GetChattingsResponse;
 import com.hyunsolution.dangu.chatting.exception.ChatRoomNotFoundException;
+import com.hyunsolution.dangu.participant.domain.Participant;
+import com.hyunsolution.dangu.participant.domain.ParticipantRepository;
 import com.hyunsolution.dangu.user.domain.User;
 import com.hyunsolution.dangu.user.domain.UserRepository;
 import com.hyunsolution.dangu.user.exception.UserNotFoundException;
@@ -32,18 +35,23 @@ public class ChattingService {
     private final UserRepository userRepository;
     private final ChatlogService chatlogService;
     private final ChatRoomRepository chatRoomRepository;
+    private final ParticipantRepository participantRepository;
 
     @Transactional(readOnly = true)
-    public List<GetChattingsResponse> getChattings(Long loginUserId, Long chatRoomId) {
+    public GetChattingsResponse getChattings(Long loginUserId, Long chatRoomId) {
         List<Chatting> chattings = chattingRepository.findByChatRoomId(chatRoomId);
-        return chattings.stream()
+        List<ChattingsDto>chattingsDtos =  chattings.stream()
                 .map(
                         chatting -> {
                             boolean isOwn = isOwn(loginUserId, chatting.getSender().getId());
-                            return GetChattingsResponse.of(
+                            return ChattingsDto.of(
                                     chatting.getContent(), chatting.getId(), isOwn);
                         })
                 .toList();
+
+    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow(() -> ChatRoomNotFoundException.EXCEPTION);
+
+    return GetChattingsResponse.of(getOtherPeople(chatRoom,loginUserId), chattingsDtos);
     }
 
     @Transactional(readOnly = true)
@@ -56,7 +64,7 @@ public class ChattingService {
                                 GetChatRoomsResponse.of(
                                         chatRoom.getId(),
                                         getLastMessage(chatRoom.getId()),
-                                        getOtherPerson(chatRoom, userId),
+                                        getOtherPeople(chatRoom, userId),
                                         getUnReadCount(chatRoom.getId(), userId)))
                 .toList();
     }
@@ -65,7 +73,7 @@ public class ChattingService {
         return loginUserId.equals(chattingUserId);
     }
 
-    private List<String> getOtherPerson(ChatRoom chatRoom, Long loginUserId) {
+    private List<String> getOtherPeople(ChatRoom chatRoom, Long loginUserId) {
         return chatRoom.getParticipants().stream()
                 .filter(participant -> !participant.getUser().getId().equals(loginUserId))
                 .map(participant -> participant.getUser().getUid())

--- a/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
@@ -46,21 +46,21 @@ public class ChattingService {
                                     boolean isOwn =
                                             isOwn(loginUserId, chatting.getSender().getId());
                                     return ChattingsDto.of(
-                                            chatting.getContent(), chatting.getId(), isOwn, chatting.getMessageType());
+                                            chatting.getContent(),
+                                            chatting.getId(),
+                                            isOwn,
+                                            chatting.getMessageType());
                                 })
                         .toList();
 
-        ChatRoom chatRoom =
-                chatRoomRepository
-                        .findById(chatRoomId)
-                        .orElseThrow(() -> ChatRoomNotFoundException.EXCEPTION);
-
+        ChatRoom chatRoom = chatRoomRepository.findByChatRoomIdWithFetchJoin(chatRoomId);
         return GetChattingsResponse.of(getOtherPeople(chatRoom, loginUserId), chattingsDtos);
     }
 
     @Transactional(readOnly = true)
     public List<GetChatRoomsResponse> getChatRooms(Long userId) {
-        List<ChatRoom> chatRooms = chatRoomRepository.findByParticipantUserId(userId);
+        List<ChatRoom> chatRooms =
+                chatRoomRepository.findByParticipantUserIdWithEntityGraph(userId);
         return chatRooms.stream()
                 .sorted(Comparator.comparing(ChatRoom::getChatUpdateAt).reversed())
                 .map(
@@ -76,7 +76,6 @@ public class ChattingService {
     private boolean isOwn(Long loginUserId, Long chattingUserId) {
         return loginUserId.equals(chattingUserId);
     }
-
 
     private List<String> getOtherPeople(ChatRoom chatRoom, Long loginUserId) {
         return chatRoom.getParticipants().stream()

--- a/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
@@ -46,7 +46,7 @@ public class ChattingService {
                                     boolean isOwn =
                                             isOwn(loginUserId, chatting.getSender().getId());
                                     return ChattingsDto.of(
-                                            chatting.getContent(), chatting.getId(), isOwn);
+                                            chatting.getContent(), chatting.getId(), isOwn, chatting.getMessageType());
                                 })
                         .toList();
 
@@ -76,6 +76,7 @@ public class ChattingService {
     private boolean isOwn(Long loginUserId, Long chattingUserId) {
         return loginUserId.equals(chattingUserId);
     }
+
 
     private List<String> getOtherPeople(ChatRoom chatRoom, Long loginUserId) {
         return chatRoom.getParticipants().stream()

--- a/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/service/ChattingService.java
@@ -10,11 +10,10 @@ import com.hyunsolution.dangu.chatting.domain.Chatting;
 import com.hyunsolution.dangu.chatting.domain.ChattingRepository;
 import com.hyunsolution.dangu.chatting.domain.MessageType;
 import com.hyunsolution.dangu.chatting.dto.response.ChatMessageDetailResponse;
-import com.hyunsolution.dangu.chatting.dto.response.GetChatRoomsResponse;
 import com.hyunsolution.dangu.chatting.dto.response.ChattingsDto;
+import com.hyunsolution.dangu.chatting.dto.response.GetChatRoomsResponse;
 import com.hyunsolution.dangu.chatting.dto.response.GetChattingsResponse;
 import com.hyunsolution.dangu.chatting.exception.ChatRoomNotFoundException;
-import com.hyunsolution.dangu.participant.domain.Participant;
 import com.hyunsolution.dangu.participant.domain.ParticipantRepository;
 import com.hyunsolution.dangu.user.domain.User;
 import com.hyunsolution.dangu.user.domain.UserRepository;
@@ -40,18 +39,23 @@ public class ChattingService {
     @Transactional(readOnly = true)
     public GetChattingsResponse getChattings(Long loginUserId, Long chatRoomId) {
         List<Chatting> chattings = chattingRepository.findByChatRoomId(chatRoomId);
-        List<ChattingsDto>chattingsDtos =  chattings.stream()
-                .map(
-                        chatting -> {
-                            boolean isOwn = isOwn(loginUserId, chatting.getSender().getId());
-                            return ChattingsDto.of(
-                                    chatting.getContent(), chatting.getId(), isOwn);
-                        })
-                .toList();
+        List<ChattingsDto> chattingsDtos =
+                chattings.stream()
+                        .map(
+                                chatting -> {
+                                    boolean isOwn =
+                                            isOwn(loginUserId, chatting.getSender().getId());
+                                    return ChattingsDto.of(
+                                            chatting.getContent(), chatting.getId(), isOwn);
+                                })
+                        .toList();
 
-    ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow(() -> ChatRoomNotFoundException.EXCEPTION);
+        ChatRoom chatRoom =
+                chatRoomRepository
+                        .findById(chatRoomId)
+                        .orElseThrow(() -> ChatRoomNotFoundException.EXCEPTION);
 
-    return GetChattingsResponse.of(getOtherPeople(chatRoom,loginUserId), chattingsDtos);
+        return GetChattingsResponse.of(getOtherPeople(chatRoom, loginUserId), chattingsDtos);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/hyunsolution/dangu/participant/domain/ParticipantRepository.java
+++ b/src/main/java/com/hyunsolution/dangu/participant/domain/ParticipantRepository.java
@@ -10,7 +10,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     // 같은 방에 있는 사람들 id(PK) 리스트
     @Query(value = "SELECT p.id FROM Participant p WHERE p.chatRoom.id=:chatRoomId")
-    List<Long> findParticipantIdByChatRoomId(Long chatRoomId);
+    List<Long> findIdByChatRoomId(Long chatRoomId);
 
     // ID별 매칭버튼 클릭 여부
     @Query(

--- a/src/main/java/com/hyunsolution/dangu/participant/service/ParticipantService.java
+++ b/src/main/java/com/hyunsolution/dangu/participant/service/ParticipantService.java
@@ -102,7 +102,7 @@ public class ParticipantService {
 
     // 모든 참가자가 매칭되었는지 확인
     private boolean allParticipantsMatched(Long chatRoomId) {
-        List<Long> participantIds = participantRepository.findParticipantIdByChatRoomId(chatRoomId);
+        List<Long> participantIds = participantRepository.findIdByChatRoomId(chatRoomId);
         return participantRepository.existsByIdAndParticipantMatchTrue(participantIds);
     }
 

--- a/src/main/java/com/hyunsolution/dangu/workspace/domain/WorkspaceRepository.java
+++ b/src/main/java/com/hyunsolution/dangu/workspace/domain/WorkspaceRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
     @Query(
-            "select w from Workspace w where w.isMatched = false and w.createdAt >= :startTime and w.createdAt <= :endTime and w.isDeleted = false")
+            "select w from Workspace w where w.isMatched = false and w.createdAt >= :startTime and w.createdAt <= :endTime and w.isDeleted = false order by w.id desc ")
     List<Workspace> findUnmatchedAndCreatedWithinDay(
             LocalDateTime startTime, LocalDateTime endTime);
 


### PR DESCRIPTION
## ⚠️ 연관된 이슈 번호 <!--이슈번호를 작성해주세요 e.g. #11 -->
- close #82 
## 📋 작업 내용
1. 쿼리 메소드 네이밍 수정
- chatRoomId로 조회하고 있어서 findIdByChatRoomId로 수정
2. 채팅 조회시 상대방 이름 값 응답보내도록 수정
3. otherPerson을 otherPeople 로 네이밍 변경
4. 워크스페이스(매칭 대기)목록 조회 workspace id로 내림차순 정렬
## 📷 스크린샷(선택) 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> e.g. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
