### PR TITLE
feat: 대전 페이지 목록 조회 및 부가기능 구현

### DIFF
--- a/src/main/java/com/hyunsolution/dangu/chatlog/domain/ChatLogRepository.java
+++ b/src/main/java/com/hyunsolution/dangu/chatlog/domain/ChatLogRepository.java
@@ -1,11 +1,14 @@
 package com.hyunsolution.dangu.chatlog.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
     @Query("select cl from ChatLog cl where cl.chatRoom.id =:chatRoomId and cl.user.id =:userId")
     Optional<ChatLog> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
@@ -17,4 +20,14 @@ public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
             @Param("userId") Long userId,
             @Param("chatRoomId") Long chatRoomId,
             @Param("readCount") int readCount);
+
+    // chatLog 속 사용자 id가 포함된 항목 추출
+    @Query("SELECT c FROM ChatLog c WHERE c.user.id=:userId ")
+    List<ChatLog> findByUserId(@Param("userId") Long userId);
+
+    // 사용자가 포함된 게임방 속 상대방 닉네임 추출
+    @Query(
+            "SELECT c.user.uid FROM ChatLog c WHERE c.chatRoom.id= :chatRoomId AND c.user.id <> :userId ")
+    Optional<String> findUidByChatRoomIdAndUserId(
+            @Param("chatRoomId") Long chatRoomId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/hyunsolution/dangu/chatting/controller/ChattingController.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/controller/ChattingController.java
@@ -23,8 +23,9 @@ public class ChattingController {
     @GetMapping("/chattings/{chatRoomId}")
     @Operation(
             summary = "채팅방에 대한 채팅을 조회한다.",
-            description = "워크스페이스(채팅방)에 대한 채팅을 조회한다. " +
-                    "메세지 타입은 TEXT, SYSTEM, STARTGAME 세가지로 나뉘며 각각 기본 메시지, 매칭신청에 따른 시스템 문자, 매칭확정에 따른 시스템 문자를 의미한다.")
+            description =
+                    "워크스페이스(채팅방)에 대한 채팅을 조회한다. "
+                            + "메세지 타입은 TEXT, SYSTEM, STARTGAME 세가지로 나뉘며 각각 기본 메시지, 매칭신청에 따른 시스템 문자, 매칭확정에 따른 시스템 문자를 의미한다.")
     public ApiResponse<GetChattingsResponse> getChattings(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId,
             @PathVariable Long chatRoomId) {

--- a/src/main/java/com/hyunsolution/dangu/chatting/controller/ChattingController.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/controller/ChattingController.java
@@ -23,7 +23,8 @@ public class ChattingController {
     @GetMapping("/chattings/{chatRoomId}")
     @Operation(
             summary = "채팅방에 대한 채팅을 조회한다.",
-            description = "워크스페이스(채팅방)에 대한 채팅을 조회한다. 워크스페이스 당 채팅방 하나 이기 때문에 워크스페이스를 채팅방이랑 같다고 생각")
+            description = "워크스페이스(채팅방)에 대한 채팅을 조회한다. " +
+                    "메세지 타입은 TEXT, SYSTEM, STARTGAME 세가지로 나뉘며 각각 기본 메시지, 매칭신청에 따른 시스템 문자, 매칭확정에 따른 시스템 문자를 의미한다.")
     public ApiResponse<GetChattingsResponse> getChattings(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId,
             @PathVariable Long chatRoomId) {

--- a/src/main/java/com/hyunsolution/dangu/chatting/domain/MessageType.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/domain/MessageType.java
@@ -2,5 +2,6 @@ package com.hyunsolution.dangu.chatting.domain;
 
 public enum MessageType {
     TEXT, // 일반 텍스트
-    SYSTEM // 시스템 메시지(입장, 매칭 메시지)
+    SYSTEM, // 시스템 메시지(매칭 신청 메시지)
+    STARTGAME //시스템 메시지(매칭 완료 및 게임 시작 안내)
 }

--- a/src/main/java/com/hyunsolution/dangu/chatting/domain/MessageType.java
+++ b/src/main/java/com/hyunsolution/dangu/chatting/domain/MessageType.java
@@ -3,5 +3,5 @@ package com.hyunsolution.dangu.chatting.domain;
 public enum MessageType {
     TEXT, // 일반 텍스트
     SYSTEM, // 시스템 메시지(매칭 신청 메시지)
-    STARTGAME //시스템 메시지(매칭 완료 및 게임 시작 안내)
+    STARTGAME // 시스템 메시지(매칭 완료 및 게임 시작 안내)
 }

--- a/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
+++ b/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
@@ -37,7 +37,7 @@ public class GameController {
         return ApiResponse.success(null);
     }
 
-    @PostMapping("/games/{worspaceId}/score")
+    @PostMapping("/games/{workspaceId}/score")
     @Operation(summary = "참여자 별 게임 시작점수와 득점(최종)점수를 입력한다.")
     public ApiResponse<Void> saveScore(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId,

--- a/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
+++ b/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
@@ -48,7 +48,7 @@ public class GameController {
     }
 
     @GetMapping("/games")
-    @Operation(summary = "대전 페이지에서 경기목록을 조회한다.")
+    @Operation(summary = "대전 페이지에서 경기목록을 조회한다.", description = "게임방 id, 사용자 닉네임, 상대방 닉네임, 승자 닉네임를 응답으로 보내준다. 다만, 승자가 아직 없을 경우에는 'none'을 반환한다.")
     public ApiResponse<List<GetGameListResponse>> getGameList(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId) {
         List<GetGameListResponse> response = gameService.getGameList(userId);

--- a/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
+++ b/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
@@ -6,7 +6,6 @@ import com.hyunsolution.dangu.game.dto.response.EnterGameRoomResponse;
 import com.hyunsolution.dangu.game.service.GameService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,8 +30,7 @@ public class GameController {
     public ApiResponse<Void> saveTableNumber(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId,
             @PathVariable("workspaceId") Long workspaceId,
-            HttpServletRequest request) {
-        int tableNumber = Integer.parseInt(request.getParameter("tableNumber"));
+            @RequestParam("tableNumber") int tableNumber) {
         gameService.saveTableNumber(workspaceId, tableNumber);
         return ApiResponse.success(null);
     }

--- a/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
+++ b/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
@@ -48,7 +48,10 @@ public class GameController {
     }
 
     @GetMapping("/games")
-    @Operation(summary = "대전 페이지에서 경기목록을 조회한다.", description = "게임방 id, 사용자 닉네임, 상대방 닉네임, 승자 닉네임를 응답으로 보내준다. 다만, 승자가 아직 없을 경우에는 'none'을 반환한다.")
+    @Operation(
+            summary = "대전 페이지에서 경기목록을 조회한다.",
+            description =
+                    "게임방 id, 사용자 닉네임, 상대방 닉네임, 승자 닉네임를 응답으로 보내준다. 다만, 승자가 아직 없을 경우에는 'none'을 반환한다.")
     public ApiResponse<List<GetGameListResponse>> getGameList(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId) {
         List<GetGameListResponse> response = gameService.getGameList(userId);

--- a/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
+++ b/src/main/java/com/hyunsolution/dangu/game/controller/GameController.java
@@ -3,9 +3,11 @@ package com.hyunsolution.dangu.game.controller;
 import com.hyunsolution.dangu.common.apiResponse.ApiResponse;
 import com.hyunsolution.dangu.game.dto.request.GetGameScoreRequest;
 import com.hyunsolution.dangu.game.dto.response.EnterGameRoomResponse;
+import com.hyunsolution.dangu.game.dto.response.GetGameListResponse;
 import com.hyunsolution.dangu.game.service.GameService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,18 +16,18 @@ import org.springframework.web.bind.annotation.*;
 public class GameController {
     private final GameService gameService;
 
-    @GetMapping("/game/{workspaceId}")
+    @GetMapping("/games/{workspaceId}")
     @Operation(
             summary = "게임방에 입장한다.",
             description = "게임방에 입장할 시 방장이라면 당구대 번호 입력창을, 방문자면 대기화면을 띄운다.")
-    public ApiResponse<EnterGameRoomResponse> getGameRoom(
+    public ApiResponse<EnterGameRoomResponse> enterGameRoom(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId,
             @PathVariable("workspaceId") Long workspaceId) {
         EnterGameRoomResponse response = gameService.enterGameRoom(workspaceId, userId);
         return ApiResponse.success(response);
     }
 
-    @PostMapping("/game/{workspaceId}") // e.g.  /game/{workspaceId}?tableNumber=5
+    @PostMapping("/games/{workspaceId}") // e.g.  /game/{workspaceId}?tableNumber=5
     @Operation(summary = "당구대 번호를 입력한다.", description = "방장이 입력한 당구대 번호를 저장한다.")
     public ApiResponse<Void> saveTableNumber(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId,
@@ -35,7 +37,7 @@ public class GameController {
         return ApiResponse.success(null);
     }
 
-    @PostMapping("/game/{worspaceId}/score")
+    @PostMapping("/games/{worspaceId}/score")
     @Operation(summary = "참여자 별 게임 시작점수와 득점(최종)점수를 입력한다.")
     public ApiResponse<Void> saveScore(
             @Parameter(hidden = true) @RequestHeader("Authorization") Long userId,
@@ -43,5 +45,13 @@ public class GameController {
             @RequestBody GetGameScoreRequest request) {
         gameService.saveGameScore(workspaceId, userId, request);
         return ApiResponse.success(null);
+    }
+
+    @GetMapping("/games")
+    @Operation(summary = "대전 페이지에서 경기목록을 조회한다.")
+    public ApiResponse<List<GetGameListResponse>> getGameList(
+            @Parameter(hidden = true) @RequestHeader("Authorization") Long userId) {
+        List<GetGameListResponse> response = gameService.getGameList(userId);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/hyunsolution/dangu/game/domain/Game.java
+++ b/src/main/java/com/hyunsolution/dangu/game/domain/Game.java
@@ -59,5 +59,7 @@ public class Game extends BaseEntity {
     private Game(User user, Workspace workspace) {
         this.user = user;
         this.workspace = workspace;
+        this.gameRound = 1;
+        this.lose = false;
     }
 }

--- a/src/main/java/com/hyunsolution/dangu/game/domain/Game.java
+++ b/src/main/java/com/hyunsolution/dangu/game/domain/Game.java
@@ -38,9 +38,8 @@ public class Game extends BaseEntity {
     @ColumnDefault("1")
     private Integer gameRound;
 
-    @Column(nullable = false)
     @ColumnDefault("false")
-    private Boolean lose;
+    private Boolean winner;
 
     @Column(name = "start_score")
     private Integer startScore;
@@ -60,6 +59,6 @@ public class Game extends BaseEntity {
         this.user = user;
         this.workspace = workspace;
         this.gameRound = 1;
-        this.lose = false;
+        this.winner = false;
     }
 }

--- a/src/main/java/com/hyunsolution/dangu/game/dto/response/EnterGameRoomResponse.java
+++ b/src/main/java/com/hyunsolution/dangu/game/dto/response/EnterGameRoomResponse.java
@@ -1,9 +1,3 @@
 package com.hyunsolution.dangu.game.dto.response;
 
-import lombok.AllArgsConstructor;
-
-@AllArgsConstructor
-public class EnterGameRoomResponse {
-
-    private Boolean isRoomManager;
-}
+public record EnterGameRoomResponse(Boolean isRoomManager) {}

--- a/src/main/java/com/hyunsolution/dangu/game/dto/response/GetGameListResponse.java
+++ b/src/main/java/com/hyunsolution/dangu/game/dto/response/GetGameListResponse.java
@@ -1,0 +1,3 @@
+package com.hyunsolution.dangu.game.dto.response;
+
+public record GetGameListResponse(Long workspaceId, String myNickname, String opponentNickname) {}

--- a/src/main/java/com/hyunsolution/dangu/game/dto/response/GetGameListResponse.java
+++ b/src/main/java/com/hyunsolution/dangu/game/dto/response/GetGameListResponse.java
@@ -1,3 +1,4 @@
 package com.hyunsolution.dangu.game.dto.response;
 
-public record GetGameListResponse(Long workspaceId, String myNickname, String opponentNickname) {}
+public record GetGameListResponse(
+        Long workspaceId, String myNickname, String opponentNickname, String winnerNickname) {}

--- a/src/main/java/com/hyunsolution/dangu/game/service/GameService.java
+++ b/src/main/java/com/hyunsolution/dangu/game/service/GameService.java
@@ -20,10 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @AllArgsConstructor
 public class GameService {
     private final UserRepository userRepository;
@@ -109,7 +111,7 @@ public class GameService {
                 List<Game> games = gameRepository.findByWorkspaceId(workspaceId);
                 String winnerNickname = "none";
                 for (Game game : games) {
-                    System.out.println("game.getWinner():" + game.getWinner());
+                    log.info("game.getWinner():" + game.getWinner());
                     if (game.getWinner() == true) {
                         winnerNickname = game.getUser().getUid();
                         break;
@@ -119,9 +121,6 @@ public class GameService {
                         new GetGameListResponse(workspaceId, uid, opponentNickname, winnerNickname);
                 gameList.add(response);
             }
-        }
-        for (GetGameListResponse response : gameList) {
-            System.out.println(response);
         }
         return gameList;
     }

--- a/src/main/java/com/hyunsolution/dangu/game/service/GameService.java
+++ b/src/main/java/com/hyunsolution/dangu/game/service/GameService.java
@@ -85,6 +85,7 @@ public class GameService {
     public List<GetGameListResponse> getGameList(Long userId) {
         List<GetGameListResponse> gameList = new ArrayList<>();
 
+        // 사용자 닉네임
         String uid =
                 userRepository
                         .findById(userId)
@@ -96,13 +97,26 @@ public class GameService {
             ChatRoom eachChatRoom = chatLog.getChatRoom();
 
             if (eachChatRoom.isMatched()) {
+                // 상대방 닉네임
                 String opponentNickname =
                         chatLogRepository
                                 .findUidByChatRoomIdAndUserId(eachChatRoom.getId(), userId)
                                 .orElseThrow(() -> new NoSuchElementException("상대가 없는 채팅방입니다."));
+
+                // 게임방 아이디
+                Long workspaceId = eachChatRoom.getWorkspace().getId();
+                // 게임방 승자 유무 및 닉네임
+                List<Game> games = gameRepository.findByWorkspaceId(workspaceId);
+                String winnerNickname = "none";
+                for (Game game : games) {
+                    System.out.println("game.getWinner():" + game.getWinner());
+                    if (game.getWinner() == true) {
+                        winnerNickname = game.getUser().getUid();
+                        break;
+                    }
+                }
                 GetGameListResponse response =
-                        new GetGameListResponse(
-                                eachChatRoom.getWorkspace().getId(), uid, opponentNickname);
+                        new GetGameListResponse(workspaceId, uid, opponentNickname, winnerNickname);
                 gameList.add(response);
             }
         }

--- a/src/main/java/com/hyunsolution/dangu/game/service/GameService.java
+++ b/src/main/java/com/hyunsolution/dangu/game/service/GameService.java
@@ -1,25 +1,36 @@
 package com.hyunsolution.dangu.game.service;
 
+import com.hyunsolution.dangu.chatRoom.domain.ChatRoom;
+import com.hyunsolution.dangu.chatlog.domain.ChatLog;
+import com.hyunsolution.dangu.chatlog.domain.ChatLogRepository;
 import com.hyunsolution.dangu.game.domain.Game;
 import com.hyunsolution.dangu.game.domain.GameRepository;
 import com.hyunsolution.dangu.game.dto.request.GetGameScoreRequest;
 import com.hyunsolution.dangu.game.dto.response.EnterGameRoomResponse;
+import com.hyunsolution.dangu.game.dto.response.GetGameListResponse;
 import com.hyunsolution.dangu.participant.domain.Participant;
 import com.hyunsolution.dangu.participant.domain.ParticipantRepository;
 import com.hyunsolution.dangu.user.domain.User;
+import com.hyunsolution.dangu.user.domain.UserRepository;
 import com.hyunsolution.dangu.workspace.domain.Workspace;
 import com.hyunsolution.dangu.workspace.domain.WorkspaceRepository;
 import com.hyunsolution.dangu.workspace.exception.WorkspaceNotFoundException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@AllArgsConstructor
 public class GameService {
+    private final UserRepository userRepository;
     private GameRepository gameRepository;
     private WorkspaceRepository workspaceRepository;
     private ParticipantRepository participantRepository;
+    private ChatLogRepository chatLogRepository;
 
     @Transactional
     public EnterGameRoomResponse enterGameRoom(Long workspaceId, Long userId) {
@@ -68,5 +79,36 @@ public class GameService {
         // 점수 저장
         game.setStartScore(request.startScore());
         game.setFinalScore(request.finalScore());
+    }
+
+    @Transactional
+    public List<GetGameListResponse> getGameList(Long userId) {
+        List<GetGameListResponse> gameList = new ArrayList<>();
+
+        String uid =
+                userRepository
+                        .findById(userId)
+                        .map(user -> user.getUid())
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 사용자입니다."));
+        List<ChatLog> allChatLog = chatLogRepository.findByUserId(userId);
+
+        for (ChatLog chatLog : allChatLog) {
+            ChatRoom eachChatRoom = chatLog.getChatRoom();
+
+            if (eachChatRoom.isMatched()) {
+                String opponentNickname =
+                        chatLogRepository
+                                .findUidByChatRoomIdAndUserId(eachChatRoom.getId(), userId)
+                                .orElseThrow(() -> new NoSuchElementException("상대가 없는 채팅방입니다."));
+                GetGameListResponse response =
+                        new GetGameListResponse(
+                                eachChatRoom.getWorkspace().getId(), uid, opponentNickname);
+                gameList.add(response);
+            }
+        }
+        for (GetGameListResponse response : gameList) {
+            System.out.println(response);
+        }
+        return gameList;
     }
 }

--- a/src/main/java/com/hyunsolution/dangu/participant/service/ParticipantService.java
+++ b/src/main/java/com/hyunsolution/dangu/participant/service/ParticipantService.java
@@ -86,11 +86,12 @@ public class ParticipantService {
                 chatRoomRepository
                         .findById(chatRoomId)
                         .orElseThrow(() -> ChatRoomNotFoundException.EXCEPTION);
-        Chatting chatting= Chatting.builder()
-                            .chatRoom(chatRoom)
-                            .content(uid + "님이 매칭을 신청하셨습니다.")
-                            .messageType(MessageType.SYSTEM)
-                            .build();
+        Chatting chatting =
+                Chatting.builder()
+                        .chatRoom(chatRoom)
+                        .content(uid + "님이 매칭을 신청하셨습니다.")
+                        .messageType(MessageType.SYSTEM)
+                        .build();
         chattingRepository.save(chatting);
 
         // workspaceId 변수 저장

--- a/src/main/java/com/hyunsolution/dangu/participant/service/ParticipantService.java
+++ b/src/main/java/com/hyunsolution/dangu/participant/service/ParticipantService.java
@@ -86,11 +86,12 @@ public class ParticipantService {
                 chatRoomRepository
                         .findById(chatRoomId)
                         .orElseThrow(() -> ChatRoomNotFoundException.EXCEPTION);
-        Chatting.builder()
-                .chatRoom(chatRoom)
-                .content(uid + "님이 매칭을 신청하셨습니다.")
-                .messageType(MessageType.SYSTEM)
-                .build();
+        Chatting chatting= Chatting.builder()
+                            .chatRoom(chatRoom)
+                            .content(uid + "님이 매칭을 신청하셨습니다.")
+                            .messageType(MessageType.SYSTEM)
+                            .build();
+        chattingRepository.save(chatting);
 
         // workspaceId 변수 저장
         Long workspaceId = chatRoom.getWorkspace().getId();
@@ -121,8 +122,8 @@ public class ParticipantService {
         Chatting chatting =
                 Chatting.builder()
                         .chatRoom(chatRoom)
-                        .content("매칭되었습니다.")
-                        .messageType(MessageType.SYSTEM)
+                        .content("매칭되었습니다.\n대전에서 게임을 시작하세요")
+                        .messageType(MessageType.STARTGAME)
                         .build();
         chattingRepository.save(chatting);
     }


### PR DESCRIPTION
## ⚠️ 연관된 이슈 번호 #95
- close #95

## 📋 작업 내용
- 대전페이지 조회
  - 조회 시 응답으로 게임방 id, 사용자 닉네임, 상대방 닉네임, 승자 닉네임을 보내주되, 승자가 아직 없는 경우, "none"을 보낸다.
- 매칭 신청에 따른 시스템 메시지 저장
  - enum타입 추가 -> 최종: TEXT(기본), SYSTEM(매칭 신청), STARTGAME(매칭 확정)
 - 게임방 입장, 당구대 번호 입력, 점수 입력 오류 해결

## 📷 스크린샷(선택) 

## 💬 리뷰 요구사항
> game 엔티티 확인부탁드립니다~!
